### PR TITLE
Handle AWS Mobile sign-in without missing enum

### DIFF
--- a/app/src/main/java/com/example/auctionapp/LoginActivity.kt
+++ b/app/src/main/java/com/example/auctionapp/LoginActivity.kt
@@ -49,7 +49,10 @@ class LoginActivity : AppCompatActivity() {
                                 finish()
                             }
                         }
-                        SignInState.SMS_MFA, SignInState.SOFTWARE_TOKEN_MFA -> {
+                        // SOFTWARE_TOKEN_MFA is not available in the version of the AWS SDK we are
+                        // using. Handling SMS_MFA here covers MFA challenges without referencing the
+                        // missing enum value and allows the project to compile.
+                        SignInState.SMS_MFA -> {
                             if (mfaCode.isNotEmpty()) {
                                 AWSMobileClient.getInstance().confirmSignIn(mfaCode, object : Callback<SignInResult> {
                                     override fun onResult(confirmResult: SignInResult) {


### PR DESCRIPTION
## Summary
- avoid referencing the unavailable `SOFTWARE_TOKEN_MFA` sign-in state

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c28247a70832d978015d203ec35ba